### PR TITLE
fix: wasm conditional import + migration to package web 

### DIFF
--- a/lib/src/number_of_processors/processors_web.dart
+++ b/lib/src/number_of_processors/processors_web.dart
@@ -1,5 +1,5 @@
-import 'dart:html';
 import 'dart:math';
+import 'package:web/web.dart' as web;
 
 /// Returns the number of available processors for concurrent execution.
 ///
@@ -10,7 +10,7 @@ import 'dart:math';
 
 int get numberOfProcessors {
   // Get the hardware concurrency, defaulting to 1 if not available
-  final concurrency = window.navigator.hardwareConcurrency ?? 1;
+  final concurrency = web.window.navigator.hardwareConcurrency;
 
   // Subtract 1 and ensure the result is at least 1
   return max(concurrency - 1, 1);

--- a/lib/src/port/send_port.dart
+++ b/lib/src/port/send_port.dart
@@ -1,1 +1,1 @@
-export 'send_port_io.dart' if (dart.library.html) 'send_port_web.dart' if (dart.library.js) 'send_port_web.dart';
+export 'send_port_io.dart' if (dart.library.html) 'send_port_web.dart' if (dart.library.js_interop) 'send_port_web.dart';

--- a/lib/worker_manager.dart
+++ b/lib/worker_manager.dart
@@ -11,7 +11,7 @@ import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 import 'package:worker_manager/src/cancelable/cancelable.dart';
 import 'package:worker_manager/src/number_of_processors/processors_io.dart'
-    if (dart.library.js) 'package:worker_manager/src/number_of_processors/processors_web.dart'
+    if (dart.library.js_interop) 'package:worker_manager/src/number_of_processors/processors_web.dart'
     if (dart.library.html) 'package:worker_manager/src/number_of_processors/processors_web.dart';
 import 'package:worker_manager/src/scheduling/task.dart';
 import 'package:worker_manager/src/scheduling/work_priority.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -337,6 +337,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  web:
+    dependency: "direct main"
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   web_socket_channel:
     dependency: transitive
     description:
@@ -362,4 +370,4 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.0.0 <4.0.0"
+  dart: ">=3.4.0 <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   async: ^2.11.0
   collection: ^1.17.1
   meta: ^1.9.1
+  web: ^1.1.1
 
 dev_dependencies:
   test: ^1.24.3


### PR DESCRIPTION
With the deprecation of package dart:js in Flutter 3.29, the conditional import must be change from `if (dart.library.js)` to `if (dart.library.js_interop)`. Refer to https://dart.dev/interop/js-interop/package-web#conditional-imports

Also migrated to package web.